### PR TITLE
Omit changing long title/description text

### DIFF
--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -153,6 +153,8 @@ private
 			value.split("\n")[0,5].join("\n") + '...'
 		elsif value.length > 100
 			value[0,97] + '...'
+		else
+			value
 		end
 
 		result = { :title => title, :value => value }


### PR DESCRIPTION
When we change a long description of issue, slack receive long notification and chat messages are flowed and gone.
