### PR TITLE
Add watchers support

### DIFF
--- a/app/views/settings/_slack_settings.html.erb
+++ b/app/views/settings/_slack_settings.html.erb
@@ -22,3 +22,11 @@
 	<label for="settings_username">Slack Username</label>
 	<input type="text" id="settings_username" value="<%= settings['username'] %>" name="settings[username]" />
 </p>
+
+<p>
+	<label for="settings_display_watchers">Display Watchers?</label>
+	<select id="settings_display_watchers" value="<%= settings['display_watchers'] %>" name="settings[display_watchers]">
+		<option value="yes">Yes</option>
+		<option value="no" <%= settings['display_watchers'] != 'yes' ? %q(selected="selected") : '' %>>No</option>
+	</select>
+</p>

--- a/init.rb
+++ b/init.rb
@@ -17,7 +17,8 @@ Redmine::Plugin.register :redmine_slack do
 			'callback_url' => 'http://slack.com/callback/',
 			'channel' => nil,
 			'icon' => 'https://raw.github.com/sciyoshi/redmine-slack/gh-pages/icon.png',
-			'username' => 'redmine'
+			'username' => 'redmine',
+			'display_watchers' => 'no'
 		},
 		:partial => 'settings/slack_settings'
 end

--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -33,6 +33,11 @@ class SlackListener < Redmine::Hook::Listener
 			:short => true
 		} if Setting.plugin_redmine_slack[:display_watchers] == 'yes'
 
+		attachment[:fields] << {
+			:title => I18n.t("default_role_manager"),
+			:value => escape(User.find issue.custom_field_value(CustomField.where(name: 'Responsable').first)),
+			:short => true
+		}
 		speak msg, channel, attachment, url
 	end
 
@@ -154,7 +159,7 @@ private
 		when "category"
 			category = IssueCategory.find(detail.value) rescue nil
 			value = escape category.to_s
-		when "assigned_to"
+		when "assigned_to", 'Responsable'
 			user = User.find(detail.value) rescue nil
 			value = escape user.to_s
 		when "fixed_version"

--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -27,6 +27,12 @@ class SlackListener < Redmine::Hook::Listener
 			:short => true
 		}]
 
+		attachment[:fields] << {
+			:title => I18n.t("field_watcher"),
+			:value => escape(issue.watcher_users.join(', ')),
+			:short => true
+		} if Setting.plugin_redmine_slack[:display_watchers] == 'yes'
+
 		speak msg, channel, attachment, url
 	end
 


### PR DESCRIPTION
Hi,

I added support to display an issue's watchers when you create it.
You can configure it in the plugin's settings.

Regards.