### PR TITLE
Optionally disable notification on issue updates

### DIFF
--- a/app/views/settings/_slack_settings.html.erb
+++ b/app/views/settings/_slack_settings.html.erb
@@ -22,3 +22,8 @@
 	<label for="settings_username">Slack Username</label>
 	<input type="text" id="settings_username" value="<%= settings['username'] %>" name="settings[username]" />
 </p>
+
+<p>
+	<label for="settings_post_updates">Post Issue Updates?</label>
+	<input type="checkbox" id="settings_post_updates" value="1" name="settings[post_updates]" <%= settings['post_updates'] ? '' : 'checked="checked"' %> />
+</p>

--- a/app/views/settings/_slack_settings.html.erb
+++ b/app/views/settings/_slack_settings.html.erb
@@ -25,5 +25,5 @@
 
 <p>
 	<label for="settings_post_updates">Post Issue Updates?</label>
-	<input type="checkbox" id="settings_post_updates" value="1" name="settings[post_updates]" <%= settings['post_updates'] ? '' : 'checked="checked"' %> />
+	<input type="checkbox" id="settings_post_updates" value="1" name="settings[post_updates]" <%= settings['post_updates'] == '1' ? 'checked="checked"' : '' %> />
 </p>

--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -37,7 +37,7 @@ class SlackListener < Redmine::Hook::Listener
 		channel = channel_for_project issue.project
 		url = url_for_project issue.project
 
-		return
+		return unless channel and url and Setting.plugin_redmine_slack[:post_updates] == '1'
 
 		msg = "[#{escape issue.project}] #{escape journal.user.to_s} updated <#{object_url issue}|#{escape issue}>"
 

--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -37,7 +37,7 @@ class SlackListener < Redmine::Hook::Listener
 		channel = channel_for_project issue.project
 		url = url_for_project issue.project
 
-		return unless channel and url
+		return
 
 		msg = "[#{escape issue.project}] #{escape journal.user.to_s} updated <#{object_url issue}|#{escape issue}>"
 


### PR DESCRIPTION
Adds a setting to allow issue updates to not be published to the Slack channel. For a larger team, these can get a bit noisy.

![screen shot 2015-05-06 at 9 16 07 pm](https://cloud.githubusercontent.com/assets/80459/7507449/5c27ae22-f435-11e4-9df1-0e3eb43e4491.png)

Tested with Redmine 2.6
