### PR TITLE
Fixed public channel "#" detection

### DIFF
--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -140,17 +140,11 @@ private
 
 		cf = ProjectCustomField.find_by_name("Slack Channel")
 
-		val = [
+		[
 			(proj.custom_value_for(cf).value rescue nil),
 			(channel_for_project proj.parent),
 			Setting.plugin_redmine_slack[:channel],
 		].find{|v| v.present?}
-
-		if val.to_s.starts_with? '#'
-			val
-		else
-			nil
-		end
 	end
 
 	def detail_to_field(detail)


### PR DESCRIPTION
Fixed private channel implementation. Removed # detection.  If I have a private channel that doesn't start with # it won't let anything post to it.  Removing this check works great.  Just requires that you put the # for public channels.