### PR TITLE
Allow Private Group as a target.

### DIFF
--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -146,11 +146,9 @@ private
 			Setting.plugin_redmine_slack[:channel],
 		].find{|v| v.present?}
 
-		if val.to_s.starts_with? '#'
-			val
-		else
-			nil
-		end
+		# Channel name '-' is reserved for NOT notifying
+		return nil if val.to_s == '-'
+		val
 	end
 
 	def detail_to_field(detail)


### PR DESCRIPTION
This is a patch to enable private group as a target for the notification.
I saw #56 and solved the issue about channel name '-' (with an easy way).
