### PR TITLE
Support for private group channels. Private groups don't have "#" at …

### DIFF
--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -146,11 +146,7 @@ private
 			Setting.plugin_redmine_slack[:channel],
 		].find{|v| v.present?}
 
-		if val.to_s.starts_with? '#'
-			val
-		else
-			nil
-		end
+		val
 	end
 
 	def detail_to_field(detail)


### PR DESCRIPTION
…name start in different with public channels, so I removed unnecessary check for '#' when retrieve channel name.