### PR TITLE
Prevent Slack from displaying private issues

### DIFF
--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -8,6 +8,7 @@ class SlackListener < Redmine::Hook::Listener
 		url = url_for_project issue.project
 
 		return unless channel and url
+		return if issue.is_private?
 
 		msg = "[#{escape issue.project}] #{escape issue.author} created <#{object_url issue}|#{escape issue}>#{mentions issue.description}"
 

--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -45,6 +45,7 @@ class SlackListener < Redmine::Hook::Listener
 		url = url_for_project issue.project
 
 		return unless channel and url and Setting.plugin_redmine_slack[:post_updates] == '1'
+		return if issue.is_private?
 
 		msg = "[#{escape issue.project}] #{escape journal.user.to_s} updated <#{object_url issue}|#{escape issue}>#{mentions journal.notes}"
 
@@ -64,6 +65,7 @@ class SlackListener < Redmine::Hook::Listener
 		url = url_for_project issue.project
 
 		return unless channel and url and issue.save
+		return if issue.is_private?
 
 		msg = "[#{escape issue.project}] #{escape journal.user.to_s} updated <#{object_url issue}|#{escape issue}>"
 


### PR DESCRIPTION
This PR will not push an issue (update) to Slack if it is marked private.