### PR TITLE
Changed behavior of HTTPClient to do async post request to avoid 500

### DIFF
--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -108,10 +108,14 @@ class SlackListener < Redmine::Hook::Listener
 			end
 		end
 
-		client = HTTPClient.new
-		client.ssl_config.cert_store.set_default_paths
-		client.ssl_config.ssl_version = "SSLv23"
-		client.post url, {:payload => params.to_json}
+        begin
+		    client = HTTPClient.new
+		    client.ssl_config.cert_store.set_default_paths
+		    client.ssl_config.ssl_version = "SSLv23"
+		    client.post_async url, {:payload => params.to_json}
+        rescue
+            # Bury exception if connection error
+        end
 	end
 
 private


### PR DESCRIPTION
Changed behavior of HTTPClient to do async post request and wrap request in try catch to avoid fatal errors when saving issues in case of connections problems with the slack api