### PR TITLE
Clarified the plugin page on Redmine

### DIFF
--- a/app/views/settings/_slack_settings.html.erb
+++ b/app/views/settings/_slack_settings.html.erb
@@ -4,13 +4,17 @@
 </p>
 
 <p>
+	Generate an "Incoming Webhook" URL from the <a href="https://slack.com/apps/build/custom-integration"> Apps configuration page on Slack</a>
+</p>
+
+<p>
 	<label for="settings_channel">Slack Channel</label>
 	<input type="text" id="settings_channel" value="<%= settings['channel'] %>" name="settings[channel]" />
 </p>
 
 <p>
 	The channel can be changed on a per-project basis by creating a
-	<a href="/custom_fields/new?type=ProjectCustomField">project custom field</a> named "Slack Channel" (without quotes).
+	<a href="/custom_fields/new?type=ProjectCustomField">project custom field</a> named "#Slack Channel" (without quotes).
 </p>
 
 <p>

--- a/app/views/settings/_slack_settings.html.erb
+++ b/app/views/settings/_slack_settings.html.erb
@@ -9,12 +9,12 @@
 
 <p>
 	<label for="settings_channel">Slack Channel</label>
-	<input type="text" id="settings_channel" value="<%= settings['channel'] %>" name="settings[channel]" />
+	<input type="text" id="settings_channel" value="#<%= settings['channel'] %>" name="settings[channel]" />
 </p>
 
 <p>
 	The channel can be changed on a per-project basis by creating a
-	<a href="/custom_fields/new?type=ProjectCustomField">project custom field</a> named "#Slack Channel" (without quotes).
+	<a href="/custom_fields/new?type=ProjectCustomField">project custom field</a> named "Slack Channel" (without quotes).
 </p>
 
 <p>


### PR DESCRIPTION
The Slack URL is generated from the apps configuration page, and the channel name must include the pound symbol