### PR TITLE
Utilize Rails callbacks to also trap issues created/saved via email

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -22,3 +22,10 @@ Redmine::Plugin.register :redmine_slack do
 		},
 		:partial => 'settings/slack_settings'
 end
+
+ActionDispatch::Callbacks.to_prepare do
+	require_dependency 'issue'
+	unless Issue.included_modules.include? RedmineSlack::IssuePatch
+		Issue.send(:include, RedmineSlack::IssuePatch)
+	end
+end

--- a/lib/redmine_slack/issue_patch.rb
+++ b/lib/redmine_slack/issue_patch.rb
@@ -25,7 +25,7 @@ module RedmineSlack
 			def save_from_issue
 				self.reload
 				if not @create_already_fired
-					Redmine::Hook.call_hook(:redmine_slack_issues_edit_after_save, { :issue => self, :journal => self.current_journal})
+					Redmine::Hook.call_hook(:redmine_slack_issues_edit_after_save, { :issue => self, :journal => self.current_journal}) unless self.current_journal.nil?
 				end
 				return true
 			end

--- a/lib/redmine_slack/issue_patch.rb
+++ b/lib/redmine_slack/issue_patch.rb
@@ -1,0 +1,35 @@
+module RedmineSlack
+	module IssuePatch
+		def self.included(base) # :nodoc:
+			base.extend(ClassMethods)
+			base.send(:include, InstanceMethods)
+
+			base.class_eval do
+				unloadable # Send unloadable so it will not be unloaded in development
+				after_create :create_from_issue
+				after_save :save_from_issue
+			end
+		end
+
+		module ClassMethods
+		end
+
+		module InstanceMethods
+			def create_from_issue
+				self.reload
+				@create_already_fired = true
+				Redmine::Hook.call_hook(:redmine_slack_issues_new_after_save, { :issue => self})
+				return true
+			end
+
+			def save_from_issue
+				self.reload
+				if not @create_already_fired
+					Redmine::Hook.call_hook(:redmine_slack_issues_edit_after_save, { :issue => self, :journal => self.current_journal})
+				end
+				return true
+			end
+
+		end
+	end
+end

--- a/lib/redmine_slack/issue_patch.rb
+++ b/lib/redmine_slack/issue_patch.rb
@@ -16,14 +16,12 @@ module RedmineSlack
 
 		module InstanceMethods
 			def create_from_issue
-				self.reload
 				@create_already_fired = true
 				Redmine::Hook.call_hook(:redmine_slack_issues_new_after_save, { :issue => self})
 				return true
 			end
 
 			def save_from_issue
-				self.reload
 				if not @create_already_fired
 					Redmine::Hook.call_hook(:redmine_slack_issues_edit_after_save, { :issue => self, :journal => self.current_journal}) unless self.current_journal.nil?
 				end

--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -264,6 +264,7 @@ private
 	end
 
 	def mentions text
+		return nil if text.nil?
 		names = extract_usernames text
 		names.present? ? "\nTo: " + names.join(', ') : nil
 	end

--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -1,7 +1,7 @@
 require 'httpclient'
 
 class SlackListener < Redmine::Hook::Listener
-	def controller_issues_new_after_save(context={})
+	def redmine_slack_issues_new_after_save(context={})
 		issue = context[:issue]
 
 		channel = channel_for_project issue.project
@@ -37,7 +37,7 @@ class SlackListener < Redmine::Hook::Listener
 		speak msg, channel, attachment, url
 	end
 
-	def controller_issues_edit_after_save(context={})
+	def redmine_slack_issues_edit_after_save(context={})
 		issue = context[:issue]
 		journal = context[:journal]
 


### PR DESCRIPTION
It is possible to create Redmine Issues [via e-mail](http://www.redmine.org/projects/redmine/wiki/RedmineReceivingEmails). But unfortunately Redmine does not generate any [Call Hooks](http://www.redmine.org/projects/redmine/wiki/Hooks_List) when using this feature and as a result no Slack posts are generated.

This patch offers an alternative approach. It uses [Rails callbacks](http://www.redmine.org/projects/redmine/wiki/Plugin_Internals#Using-Rails-callbacks-in-Redmine-plugins) in order to watch the Redmine Issue Model and generate Redmine Hooks using other naming (not controller based), also paying attention to avoid generating duplicate hooks or Slack posts. Thus, the listener is refactored to use these alternative hook names.
