### PR TITLE
Fix slack ssl connection

### DIFF
--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -152,10 +152,12 @@ class SlackListener < Redmine::Hook::Listener
 		begin
 			client = HTTPClient.new
 			client.ssl_config.cert_store.set_default_paths
-			client.ssl_config.ssl_version = "SSLv23"
+			client.ssl_config.ssl_version = :auto
 			client.post_async url, {:payload => params.to_json}
-		rescue
+		rescue Exception => e
 			# Bury exception if connection error
+			logger.warn("cannot connect to #{url}")
+			logger.warn(e)
 		end
 	end
 

--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -155,7 +155,6 @@ class SlackListener < Redmine::Hook::Listener
 			client.ssl_config.ssl_version = :auto
 			client.post_async url, {:payload => params.to_json}
 		rescue Exception => e
-			# Bury exception if connection error
 			logger.warn("cannot connect to #{url}")
 			logger.warn(e)
 		end


### PR DESCRIPTION
A quick patch to make HTTPClient auto-negotiate SSL ciphers with the server. SSLV2 and V3 aren't supported by most servers anymore.