### PR TITLE
Option for posting completed issue updates only

### DIFF
--- a/app/views/settings/_slack_settings.html.erb
+++ b/app/views/settings/_slack_settings.html.erb
@@ -41,6 +41,12 @@
 </p>
 
 <p>
+	<label for="settings_post_closed">Post Issue Closed?</label>
+	<input type="checkbox" id="settings_post_closed" value="1" name="settings[post_closed]" <%= settings['post_closed'] == '1' ? 'checked="checked"' : '' %> />
+</p>
+
+
+<p>
 	<label for="settings_post_wiki_updates">Post Wiki Updates?</label>
 	<input type="checkbox" id="settings_post_wiki_updates" value="1" name="settings[post_wiki_updates]" <%= settings['post_wiki_updates'] == '1' ? 'checked="checked"' : '' %> />
 </p>

--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -44,7 +44,7 @@ class SlackListener < Redmine::Hook::Listener
 		channel = channel_for_project issue.project
 		url = url_for_project issue.project
 
-		return unless channel and url and Setting.plugin_redmine_slack[:post_updates] == '1'
+		return unless channel and url and (Setting.plugin_redmine_slack[:post_updates] == '1' or ( Setting.plugin_redmine_slack[:post_closed] == '1' and issue.status.is_closed ) )
 		return if issue.is_private?
 
 		msg = "[#{escape issue.project}] #{escape journal.user.to_s} updated <#{object_url issue}|#{escape issue}>#{mentions journal.notes}"


### PR DESCRIPTION
This is pretty ugly, was just a quick fix to get this working how my business wanted to see updates. Ideally there should be some smarts around how the settings page displays this option, however i'm a Django guy, not a Rails guy, so I'll leave that up to the people who know it better.
Signed-off-by: Ben Fitzhardinge <ben.fitzhardinge@ch2.net.au>