### PR TITLE
Add Slack Username registration feature

### DIFF
--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -3,7 +3,7 @@ require 'httpclient'
 class SlackListener < Redmine::Hook::Listener
 
 	def initialize
-		@slack_user_name_custom_field = UserCustomField.find_by_name("Slack Username")
+		@slack_username_custom_field = UserCustomField.find_by_name("Slack Username")
 	end
 
 	def controller_issues_new_after_save(context={})
@@ -290,7 +290,7 @@ private
 		end
 
 		if user.present?
-			val = user.custom_value_for(@slack_user_name_custom_field).value rescue nil
+			val = user.custom_value_for(@slack_username_custom_field).value rescue nil
 			if val.nil?
 				return val
 			end

--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -53,7 +53,7 @@ class SlackListener < Redmine::Hook::Listener
 		return if issue.is_private?
 		return if journal.private_notes?
 
-		msg = "[#{escape issue.project}] #{escape journal.user.to_s} updated <#{object_url issue}|#{escape issue}>#{mentions journal.notes}"
+		msg = "[#{escape issue.project}] #{escape journal.user.to_s} updated <#{object_url issue}#change-#{journal.id}|#{escape issue}>#{mentions journal.notes}"
 
 		attachment = {}
 		attachment[:text] = escape journal.notes if journal.notes

--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -317,13 +317,14 @@ private
 	end
 
 	def extract_usernames text = ''
-		# 指定されたテキストから @xxxxx のメンションを抜き出し、ユーザー名(xxxxx の部分のみ)のリストを返します。
+		# Extracts the @xxxxx from the given text and returns a list of usernames (only xxxxx parts)
+
 		if text.nil?
 			text = ''
 		end
 
 		text.scan(/@[a-z0-9][a-z0-9_\-.]*/).uniq.each do |username|
-			# 先頭の @ を除去
+			# Remove the leading @
 			username.slice!(0)
 		end
 	end
@@ -338,10 +339,10 @@ private
 	end
 
 	def build_mentions(assignee_user, text, project_id)
-		# 担当者の Redmine User インスタンスを取得
+		# Get the assignee's Redmine User instance
 		assignee_slack_username = find_slack_username(assignee_user, project_id)
 
-		# コメントからメンションされた Redmine ユーザー名リストを取得
+		# Retrieve the mentioned Redmine usernames from the given text
 		mentioned_usernames = extract_usernames text
 		slack_usernames = to_slack_usernames(mentioned_usernames, project_id)
 
@@ -349,7 +350,7 @@ private
 			slack_usernames << assignee_slack_username
 		end
 
-		# メンションする Slack ユーザー名リスト
+		# Slack usernames to be mentioned
 		slack_usernames = slack_usernames.uniq.map { |name| '@' + name }
 		slack_usernames.present? ? "\n" + slack_usernames.join(' ') : nil
 	end


### PR DESCRIPTION
- You can register the Slack username in the user's account settings.
   - Administrator needs to create a user custom field named "Slack Username".
   - If Slack's username is different for each project, register it like "project_identifier_1: slack_username_1, project_identifier_2: slack_username_2".
- If Redmine 's user ID and Slack' s username are different, "@redmine_user_id" in an issue comment  will be converted to Slack username registered by that user and posted to Slack.
- When a assignee of an issue is changed, the message with "@assignee_slack_username" mention is posted to Slack.