### PR TITLE
some custom field value in slack posts is not unformatted

### DIFF
--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -212,16 +212,16 @@ private
 	end
 
 	def detail_to_field(detail)
-    case detail.property
-    when "cf"
-      custom_field = detail.custom_field
-      key = custom_field.name
+		case detail.property
+		when "cf"
+			custom_field = detail.custom_field
+			key = custom_field.name
 			title = key
-      value = (detail.value)? IssuesController.helpers.format_value(detail.value, custom_field) : ""
-    when "attachment"
+			value = (detail.value)? IssuesController.helpers.format_value(detail.value, custom_field) : ""
+		when "attachment"
 			key = "attachment"
 			title = I18n.t :label_attachment
-      value = escape detail.value.to_s
+			value = escape detail.value.to_s
 		else
 			key = detail.prop_key.to_s.sub("_id", "")
 			if key == "parent"
@@ -229,7 +229,7 @@ private
 			else
 				title = I18n.t "field_#{key}"
 			end
-      value = escape detail.value.to_s
+			value = escape detail.value.to_s
 		end
 
 		short = true

--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -217,7 +217,7 @@ private
       custom_field = detail.custom_field
       key = custom_field.name
 			title = key
-      value = IssuesController.helpers.format_value(detail.value, custom_field) if detail.value
+      value = (detail.value)? IssuesController.helpers.format_value(detail.value, custom_field) : ""
     when "attachment"
 			key = "attachment"
 			title = I18n.t :label_attachment

--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -212,12 +212,16 @@ private
 	end
 
 	def detail_to_field(detail)
-		if detail.property == "cf"
-			key = CustomField.find(detail.prop_key).name rescue nil
+    case detail.property
+    when "cf"
+      custom_field = detail.custom_field
+      key = custom_field.name
 			title = key
-		elsif detail.property == "attachment"
+      value = IssuesController.helpers.format_value(detail.value, custom_field) if detail.value
+    when "attachment"
 			key = "attachment"
 			title = I18n.t :label_attachment
+      value = escape detail.value.to_s
 		else
 			key = detail.prop_key.to_s.sub("_id", "")
 			if key == "parent"
@@ -225,10 +229,10 @@ private
 			else
 				title = I18n.t "field_#{key}"
 			end
+      value = escape detail.value.to_s
 		end
 
 		short = true
-		value = escape detail.value.to_s
 
 		case key
 		when "title", "subject", "description"


### PR DESCRIPTION
1. add a custom field whose type is set to "User", for example
2. modify and update a custom field value in an issue
3. the update is notified to a slack channel:
    * Expected: user name should be displayed
    * Actual: a number (user ID) is displayed.

`format_value` should be used for formatting custom field values, but actual implementation is not so.

This PR fixes this bug.