### PR TITLE
Avoid wiki notif if project config has "-" in channel name

### DIFF
--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -120,6 +120,8 @@ class SlackListener < Redmine::Hook::Listener
 
 		channel = channel_for_project project
 		url = url_for_project project
+		
+		return unless channel and url
 
 		attachment = nil
 		if not page.content.comments.empty?


### PR DESCRIPTION
This PR should resolve the issue #134 by avoiding wiki notifications if the Slack channel in the project configuration has been set to "-"