### PR TITLE
support for redmine6

### DIFF
--- a/lib/redmine_slack/issue_patch.rb
+++ b/lib/redmine_slack/issue_patch.rb
@@ -5,7 +5,7 @@ module RedmineSlack
 			base.send(:include, InstanceMethods)
 
 			base.class_eval do
-				unloadable # Send unloadable so it will not be unloaded in development
+				unloadable if respond_to?(:unloadable)  # Send unloadable so it will not be unloaded in development
 				after_create :create_from_issue
 				after_save :save_from_issue
 			end


### PR DESCRIPTION
make unloadable call only if unloadable exists.

Redmine 6 bumped rails version to 7. Rails 7 has removed unloadable and no longer required in Rails7. To keep compatibility with legacy versions, leave call it if present.